### PR TITLE
Added IEnumerable<T> support for population / comparison

### DIFF
--- a/Amido.NAuto.Tests/Builders/Services/PopulateListServiceTests.cs
+++ b/Amido.NAuto.Tests/Builders/Services/PopulateListServiceTests.cs
@@ -30,15 +30,32 @@ namespace Amido.NAuto.UnitTests.Builders.Services
             public void Should_Instantiate_And_Populate_List_With_Correct_Values()
             {
                 const string propertyName = "property";
-                var type = typeof (List<string>);
+                var type = typeof(List<string>);
                 const int depth = 0;
                 const string listValue = "string";
-                var populate = new Func<int, string, Type, object, PropertyInfo, object>((d,p,t,i,v) => listValue) ;
+                var populate = new Func<int, string, Type, object, PropertyInfo, object>((d, p, t, i, v) => listValue);
 
                 var result = populateListService.Populate(propertyName, type, null, depth, populate) as List<string>;
 
                 result.ShouldNotBeNull();
                 result.Count.ShouldEqual(autoBuilderConfiguration.DefaultCollectionItemCount);
+                result.First().ShouldEqual(listValue);
+                result.Last().ShouldEqual(listValue);
+            }
+
+            [Test]
+            public void Should_Instantiate_And_Populate_IEnumerable_With_Correct_Values()
+            {
+                const string propertyName = "property";
+                var type = typeof(IEnumerable<string>);
+                const int depth = 0;
+                const string listValue = "string";
+                var populate = new Func<int, string, Type, object, PropertyInfo, object>((d, p, t, i, v) => listValue);
+
+                var result = populateListService.Populate(propertyName, type, null, depth, populate) as IEnumerable<string>;
+
+                result.ShouldNotBeNull();
+                result.Count().ShouldEqual(autoBuilderConfiguration.DefaultCollectionItemCount);
                 result.First().ShouldEqual(listValue);
                 result.Last().ShouldEqual(listValue);
             }
@@ -58,6 +75,25 @@ namespace Amido.NAuto.UnitTests.Builders.Services
                 result.ShouldNotBeNull();
                 result.ShouldEqual(list);
                 result.Count.ShouldEqual(autoBuilderConfiguration.DefaultCollectionItemCount);
+                result.First().ShouldEqual(listValue);
+                result.Last().ShouldEqual(listValue);
+            }
+
+            [Test]
+            public void Should_Use_Passed_In_IEnumerable_And_Populate_IEnumerable_With_Correct_Values()
+            {
+                const string propertyName = "property";
+                var list = new List<string>().AsEnumerable();
+                var type = typeof(List<string>);
+                const int depth = 0;
+                const string listValue = "string";
+                var populate = new Func<int, string, Type, object, PropertyInfo, object>((d, p, t, i, v) => listValue);
+
+                var result = populateListService.Populate(propertyName, type, list, depth, populate) as IEnumerable<string>;
+
+                result.ShouldNotBeNull();
+                result.ShouldEqual(list);
+                result.Count().ShouldEqual(autoBuilderConfiguration.DefaultCollectionItemCount);
                 result.First().ShouldEqual(listValue);
                 result.Last().ShouldEqual(listValue);
             }

--- a/Amido.NAuto.Tests/Builders/Services/PropertyPopulationServiceTests.cs
+++ b/Amido.NAuto.Tests/Builders/Services/PropertyPopulationServiceTests.cs
@@ -41,7 +41,7 @@ namespace Amido.NAuto.UnitTests.Builders.Services
         private Mock<IPopulateDictionaryService> populateDictionaryService;
         private Mock<IPopulateArrayService> populateArrayService;
         private AutoBuilderConfiguration autoBuilderConfiguration;
-            
+
         [SetUp]
         public void SetUp()
         {
@@ -221,6 +221,16 @@ namespace Amido.NAuto.UnitTests.Builders.Services
                 public List<string> Test { get; set; }
 
                 public ListTest()
+                {
+                    Test = new List<string>();
+                }
+            }
+
+            private class IEnumerableTest
+            {
+                public IEnumerable<string> Test { get; set; }
+
+                public IEnumerableTest()
                 {
                     Test = new List<string>();
                 }
@@ -533,11 +543,11 @@ namespace Amido.NAuto.UnitTests.Builders.Services
             {
                 // Arrange
                 populateComplexObjectService.Setup(x => x.Populate(
-                    It.IsAny<string>(), 
-                    typeof(StringTest), 
-                    null, 
+                    It.IsAny<string>(),
+                    typeof(StringTest),
+                    null,
                     0,
-                    It.IsAny<Func<ConstructorInfo[], int, Func<int, string, Type, object, PropertyInfo, object>, object[]>>(), 
+                    It.IsAny<Func<ConstructorInfo[], int, Func<int, string, Type, object, PropertyInfo, object>, object[]>>(),
                     It.IsAny<Func<int, string, Type, object, PropertyInfo, object>>(),
                     It.IsAny<Func<object, int, object>>())).Returns(null);
 
@@ -562,6 +572,25 @@ namespace Amido.NAuto.UnitTests.Builders.Services
 
                 // Act
                 propertyPopulationService.PopulateProperties(new ListTest(), 0);
+
+                // Assert
+                populateListService.VerifyAll();
+            }
+
+            [Test]
+            public void Should_Call_Correct_Populate_Service_When_Passed_An_IEnumerable()
+            {
+                // Arrange
+                populateListService.Setup(x => x.Populate(
+                        It.IsAny<string>(),
+                        typeof(IEnumerable<string>),
+                        It.IsAny<IEnumerable<string>>(),
+                        0,
+                        It.IsAny<Func<int, string, Type, object, PropertyInfo, object>>()))
+                    .Returns(null);
+
+                // Act
+                propertyPopulationService.PopulateProperties(new IEnumerableTest(), 0);
 
                 // Assert
                 populateListService.VerifyAll();

--- a/Amido.NAuto.Tests/Compare/ModelPropertyComparerTests.cs
+++ b/Amido.NAuto.Tests/Compare/ModelPropertyComparerTests.cs
@@ -53,6 +53,8 @@ namespace Amido.NAuto.UnitTests.Compare
 
             public List<SubClass> SubClassList { get; set; }
 
+            public IEnumerable<SubClass> SubClassEnumerable { get; set; }
+
             public Dictionary<string, SubClass> MyDictionary { get; set; }
 
             public TestEnum TestEnum { get; set; }
@@ -73,6 +75,7 @@ namespace Amido.NAuto.UnitTests.Compare
             public SubClass SubClass { get; set; }
 
             public List<SubClass> SubClassList { get; set; }
+            public IEnumerable<SubClass> SubClassEnumerable { get; set; }
 
             public Dictionary<string, SubClass> MyDictionary { get; set; }
 
@@ -94,5 +97,4 @@ namespace Amido.NAuto.UnitTests.Compare
             public string SubString { get; set; }
         }
     }
-
 }

--- a/Amido.NAuto/Builders/Services/PopulateListService.cs
+++ b/Amido.NAuto/Builders/Services/PopulateListService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Amido.NAuto.Builders.Services
@@ -14,9 +15,9 @@ namespace Amido.NAuto.Builders.Services
         }
 
         public object Populate(
-            string propertyName, 
-            Type propertyType, 
-            object currentValue, 
+            string propertyName,
+            Type propertyType,
+            object currentValue,
             int depth,
             Func<int, string, Type, object, PropertyInfo, object> populate)
         {
@@ -24,6 +25,8 @@ namespace Amido.NAuto.Builders.Services
             {
                 return currentValue;
             }
+
+            var listType = propertyType.GetGenericArguments()[0];
 
             IList newList;
 
@@ -33,12 +36,12 @@ namespace Amido.NAuto.Builders.Services
             }
             else
             {
-                newList = (IList)Activator.CreateInstance(propertyType);
+                newList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(listType));
             }
 
             for (var i = 0; i < AutoBuilderConfiguration.DefaultCollectionItemCount; i++)
             {
-                newList.Add(populate(depth + 1, propertyName, propertyType.GetGenericArguments()[0], null, null));
+                newList.Add(populate(depth + 1, propertyName, listType, null, null));
             }
 
             return newList;

--- a/Amido.NAuto/Builders/Services/PropertyPopulationService.cs
+++ b/Amido.NAuto/Builders/Services/PropertyPopulationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -36,7 +37,7 @@ namespace Amido.NAuto.Builders.Services
         private AutoBuilderConfiguration configuration;
 
         public PropertyPopulationService(
-            PopulateProperty<string> populateStringService, 
+            PopulateProperty<string> populateStringService,
             PopulateProperty<int> populateIntService,
             PopulateProperty<int?> populateNullableIntProperty,
             PopulateProperty<double> populateDoubleService,
@@ -130,9 +131,9 @@ namespace Amido.NAuto.Builders.Services
 
             var objectToPopulateType = objectToPopulate.GetType();
 
-            if (objectToPopulateType.GetInterfaces().Any(x => x == typeof(IList)))
+            if (objectToPopulateType.GetInterfaces().Any(x => x == typeof(IList) || x == typeof(IEnumerable)))
             {
-                if (objectToPopulateType.FullName.Contains("System.Collections.Generic.List`1"))
+                if (objectToPopulateType.FullName.Contains("System.Collections.Generic.List`1") || objectToPopulateType.FullName.Contains("System.Collections.Generic.IEnumerable`1"))
                 {
                     populateListService.Populate(string.Empty, objectToPopulateType, objectToPopulate, depth - 1, Populate);
                 }
@@ -164,7 +165,7 @@ namespace Amido.NAuto.Builders.Services
                             objectToPopulate,
                             Populate(depth, propertyInfo.Name, propertyInfo.PropertyType, propertyInfo.GetValue(objectToPopulate, null), propertyInfo), null);
                     }
-                } 
+                }
             }
 
             return objectToPopulate;
@@ -187,12 +188,12 @@ namespace Amido.NAuto.Builders.Services
                 if (!propertyInfo.CanWrite)
                 {
                     return value;
-                }    
+                }
             }
 
-            if (propertyType.GetInterfaces().Any(x => x == typeof(IList)))
+            if (propertyType.GetInterfaces().Any(x => x == typeof(IList) || x == typeof(IEnumerable)))
             {
-                if (propertyType.FullName.Contains("System.Collections.Generic.List`1"))
+                if (propertyType.FullName.Contains("System.Collections.Generic.List`1") || propertyType.FullName.Contains("System.Collections.Generic.IEnumerable`1"))
                 {
                     return populateListService.Populate(propertyName, propertyType, value, depth, Populate);
                 }
@@ -322,7 +323,7 @@ namespace Amido.NAuto.Builders.Services
             {
                 return populateEnumService.Populate(propertyName, propertyType, value);
             }
-            
+
             if (IsPotentialComplexType(propertyType))
             {
                 return populateComplexObjectService.Populate(


### PR DESCRIPTION
Support for IEnumerable<T> now working

Main change was in `ModelPropertyComparer.cs`
Have re-ordered some of the comparers, so it does primitive types first
String in particular, since string implements `IEnumerable<char>`