### PR TITLE
fix up versioning numbers

### DIFF
--- a/Amido.NAuto/Amido.NAuto.nuspec
+++ b/Amido.NAuto/Amido.NAuto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NAuto</id>
-    <version>1.0.0.4</version>
+    <version>$version$</version>
     <title>NAuto</title>
     <authors>Sean McAlinden &amp; Andrew Jutton</authors>
     <owners>Amido Development Ltd</owners>

--- a/Amido.NAuto/Properties/AssemblyInfo.cs
+++ b/Amido.NAuto/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
-[assembly: AssemblyFileVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
+[assembly: AssemblyFileVersion("1.0.0.6")]

--- a/Amido.NAuto/Properties/AssemblyInfo.cs
+++ b/Amido.NAuto/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyFileVersion("1.0.0.5")]


### PR DESCRIPTION
$version$ tag in nuspec
picks up v number from AssemblyInfo
bumped up (wrong version currently on Nuget)

Would be good to appveyor this at some point!